### PR TITLE
Ensure lightbox starts hidden

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
     @media(min-width:600px){.cards-grid{grid-template-columns:repeat(2,1fr)}}
     @media(min-width:900px){.cards-grid{grid-template-columns:repeat(3,1fr)}}
     .lightbox{position:fixed;inset:0;background:rgba(0,0,0,.8);display:flex;align-items:center;justify-content:center;padding:20px;z-index:200}
+    .lightbox[hidden]{display:none}
     .lightbox img{max-width:100%;max-height:100%;border-radius:16px}
 
     /* Cards / Tables */


### PR DESCRIPTION
## Summary
- respect the `hidden` attribute on the lightbox overlay so it isn't shown on page load

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68be09064ff88331b05bc9a98661690e