### PR TITLE
Limitar tamaño de imágenes en lightbox de la galería

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
     @media(min-width:900px){.cards-grid{grid-template-columns:repeat(3,1fr)}}
     .lightbox{position:fixed;inset:0;background:rgba(0,0,0,.8);display:flex;align-items:center;justify-content:center;padding:20px;z-index:200}
     .lightbox[hidden]{display:none}
-    .lightbox img{max-width:100%;max-height:100%;border-radius:16px}
+    .lightbox img{width:auto;height:auto;max-width:90vw;max-height:90vh;border-radius:16px}
 
     /* Cards / Tables */
     .card{background:#fff;border:1px solid #e2e8f0;border-radius:16px;padding:20px;box-shadow:0 1px 2px rgba(16,24,40,.04)}


### PR DESCRIPTION
## Resumen
- Evita que las imágenes del lightbox ocupen todo el ancho de la pantalla en escritorio.
- Restringe su tamaño máximo al 90% del viewport para mantener proporciones adecuadas.

## Testing
- `npm test` *(falla: package.json no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_68be16976bf48331a9df0d3882b4b369