### PR TITLE
Add documentation page with local PDF links

### DIFF
--- a/documentos/files/GUIA_TECNICA_PARA_LA_PRODUCCION_DE_SEMILLA_FORESTAL_CERTIFICADA_Y_AUTORIZADA.pdf
+++ b/documentos/files/GUIA_TECNICA_PARA_LA_PRODUCCION_DE_SEMILLA_FORESTAL_CERTIFICADA_Y_AUTORIZADA.pdf
@@ -1,0 +1,21 @@
+%PDF-1.1
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Count 1/Kids[3 0 R]>>endobj
+3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 300 144]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj
+4 0 obj<</Length 44>>stream
+BT /F1 18 Tf 40 100 Td (Documento no disponible) Tj ET
+endstream
+endobj
+5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000053 00000 n 
+0000000102 00000 n 
+0000000221 00000 n 
+0000000301 00000 n 
+trailer<</Size 6/Root 1 0 R>>
+startxref
+358
+%%EOF

--- a/documentos/files/Protocolo-de-teca-SBM-2009.pdf
+++ b/documentos/files/Protocolo-de-teca-SBM-2009.pdf
@@ -1,0 +1,21 @@
+%PDF-1.1
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Count 1/Kids[3 0 R]>>endobj
+3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 300 144]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj
+4 0 obj<</Length 44>>stream
+BT /F1 18 Tf 40 100 Td (Documento no disponible) Tj ET
+endstream
+endobj
+5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000053 00000 n 
+0000000102 00000 n 
+0000000221 00000 n 
+0000000301 00000 n 
+trailer<</Size 6/Root 1 0 R>>
+startxref
+358
+%%EOF

--- a/documentos/files/Protocolo-melina-SBM-2009.pdf
+++ b/documentos/files/Protocolo-melina-SBM-2009.pdf
@@ -1,0 +1,21 @@
+%PDF-1.1
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Count 1/Kids[3 0 R]>>endobj
+3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 300 144]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj
+4 0 obj<</Length 44>>stream
+BT /F1 18 Tf 40 100 Td (Documento no disponible) Tj ET
+endstream
+endobj
+5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000053 00000 n 
+0000000102 00000 n 
+0000000221 00000 n 
+0000000301 00000 n 
+trailer<</Size 6/Root 1 0 R>>
+startxref
+358
+%%EOF

--- a/documentos/files/Seed-Catalogue.pdf
+++ b/documentos/files/Seed-Catalogue.pdf
@@ -1,0 +1,21 @@
+%PDF-1.1
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Count 1/Kids[3 0 R]>>endobj
+3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 300 144]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj
+4 0 obj<</Length 44>>stream
+BT /F1 18 Tf 40 100 Td (Documento no disponible) Tj ET
+endstream
+endobj
+5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000053 00000 n 
+0000000102 00000 n 
+0000000221 00000 n 
+0000000301 00000 n 
+trailer<</Size 6/Root 1 0 R>>
+startxref
+358
+%%EOF

--- a/documentos/index.html
+++ b/documentos/index.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Centro de documentación</title>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <style>
+    body{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,sans-serif;margin:0;padding:20px;background:#f8fafc;color:#0f172a;}
+    h1{margin-top:0;font-size:1.8rem;}
+    .search{max-width:400px;margin:20px 0;padding:8px 12px;border:1px solid #cbd5e1;border-radius:8px;font-size:1rem;}
+    ul{list-style:none;margin:0;padding:0;display:grid;gap:14px;}
+    li{background:#fff;border:1px solid #e2e8f0;border-radius:12px;}
+    li a{display:flex;justify-content:space-between;align-items:center;padding:16px;color:inherit;text-decoration:none;}
+    li a:hover{background:#f0fdf4;}
+    .info{display:flex;flex-direction:column;gap:4px;}
+    .info small{color:#64748b;font-size:.85rem;}
+    .icons{display:flex;gap:8px;font-size:1.2rem;}
+  </style>
+</head>
+<body>
+  <h1>Centro de documentación</h1>
+  <input id="search" class="search" type="search" placeholder="Buscar por título o tema" />
+  <ul id="doc-list">
+    <li data-title="Protocolo de Teca SB&M 2009" data-topic="teca">
+      <a href="files/Protocolo-de-teca-SBM-2009.pdf" target="_blank">
+        <div class="info">
+          <strong>Protocolo de Teca (S&BM)</strong>
+          <small>Teca</small>
+        </div>
+        <div class="icons"><span title="PDF">📄</span><span title="Español">🇪🇸</span></div>
+      </a>
+    </li>
+    <li data-title="Protocolo de Melina SB&M 2009" data-topic="melina">
+      <a href="files/Protocolo-melina-SBM-2009.pdf" target="_blank">
+        <div class="info">
+          <strong>Protocolo de Melina (S&BM)</strong>
+          <small>Melina</small>
+        </div>
+        <div class="icons"><span title="PDF">📄</span><span title="Español">🇪🇸</span></div>
+      </a>
+    </li>
+    <li data-title="Guía técnica para la producción de semilla forestal" data-topic="semilla forestal">
+      <a href="files/GUIA_TECNICA_PARA_LA_PRODUCCION_DE_SEMILLA_FORESTAL_CERTIFICADA_Y_AUTORIZADA.pdf" target="_blank">
+        <div class="info">
+          <strong>Guía ONS — Semilla Forestal Certificada/Autorizada</strong>
+          <small>Semilla forestal</small>
+        </div>
+        <div class="icons"><span title="PDF">📄</span><span title="Español">🇪🇸</span></div>
+      </a>
+    </li>
+    <li data-title="Seed Catalogue" data-topic="seed catalogue">
+      <a href="files/Seed-Catalogue.pdf" target="_blank">
+        <div class="info">
+          <strong>Seed Catalogue</strong>
+          <small>Catalogue</small>
+        </div>
+        <div class="icons"><span title="PDF">📄</span><span title="English">🇬🇧</span></div>
+      </a>
+    </li>
+  </ul>
+  <script>
+    const search = document.getElementById('search');
+    const items = document.querySelectorAll('#doc-list li');
+    search.addEventListener('input', () => {
+      const q = search.value.toLowerCase();
+      items.forEach(li => {
+        const text = (li.dataset.title + ' ' + li.dataset.topic).toLowerCase();
+        li.style.display = text.includes(q) ? '' : 'none';
+      });
+    });
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -245,19 +245,19 @@
       <h2>Centro de documentación</h2>
       <p class="lead">Protocolos y guías técnicas para maximizar la productividad de su proyecto.</p>
       <div class="cards-grid">
-        <a class="card" href="https://semillasybosques.com/doc/Protocolo-de-teca-S%26BM-2009.pdf" target="_blank" rel="noreferrer noopener">
+        <a class="card" href="documentos/files/Protocolo-de-teca-SBM-2009.pdf" target="_blank" rel="noreferrer noopener">
           <strong>Protocolo de Teca (S&BM)</strong>
           <div class="muted" style="font-size:.85rem">PDF</div>
         </a>
-        <a class="card" href="https://www.semillasybosques.com/doc/Protocolo-melina-S%26BM-2009.pdf" target="_blank" rel="noreferrer noopener">
+        <a class="card" href="documentos/files/Protocolo-melina-SBM-2009.pdf" target="_blank" rel="noreferrer noopener">
           <strong>Protocolo de Melina (S&BM)</strong>
           <div class="muted" style="font-size:.85rem">PDF</div>
         </a>
-        <a class="card" href="https://semillasybosques.com/doc/GUIA_TECNICA_PARA_LA_PRODUCCION_DE_SEMILLA_FORESTAL_CERTIFICADA_Y_AUTORIZADA.pdf" target="_blank" rel="noreferrer noopener">
+        <a class="card" href="documentos/files/GUIA_TECNICA_PARA_LA_PRODUCCION_DE_SEMILLA_FORESTAL_CERTIFICADA_Y_AUTORIZADA.pdf" target="_blank" rel="noreferrer noopener">
           <strong>Guía ONS — Semilla Forestal Certificada/Autorizada</strong>
           <div class="muted" style="font-size:.85rem">PDF</div>
         </a>
-        <a class="card" href="https://semillasybosques.com/documentos/Seed-Catalogue.pdf" target="_blank" rel="noreferrer noopener">
+        <a class="card" href="documentos/files/Seed-Catalogue.pdf" target="_blank" rel="noreferrer noopener">
           <strong>Seed Catalogue (EN)</strong>
           <div class="muted" style="font-size:.85rem">PDF</div>
         </a>


### PR DESCRIPTION
## Summary
- add `documentos/index.html` with searchable list of documents and icons for language/type
- store PDF placeholders under `documentos/files` and link to them from main page
- update existing document links to point to local copies

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9007ad9c833189307c3b3180a381