### PR TITLE
Add footnote clarifying seed source types and viability

### DIFF
--- a/semillas/otras-especies.html
+++ b/semillas/otras-especies.html
@@ -177,6 +177,7 @@
         </table>
       </div>
       <!-- LISTA-DISPONIBLE (fin) -->
+      <p style="font-size:.875rem;color:var(--muted);margin-top:8px">Tipo Fuente: FI = Identificada, FS = Seleccionada, RS = Rodal semillero, HS = Huerto semillero<br>*Semillas viables/kg: pueden variar según la calidad física de cada lote de semillas.</p>
       <a class="btn cta" href="../#contacto" style="display:inline-flex;margin-top:24px">Solicitar disponibilidad</a>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- add footnote describing seed source type abbreviations and seed viability disclaimer on other species page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e020277483318c66f225ed2943b9